### PR TITLE
Disable FormatUsersInBidirectionalUnicode

### DIFF
--- a/IrcDiscordRelay.cs
+++ b/IrcDiscordRelay.cs
@@ -105,6 +105,7 @@ namespace IrcDiscordRelay
             discordClient = new DiscordSocketClient(
                 new DiscordSocketConfig
                 {
+                    FormatUsersInBidirectionalUnicode = False,  // This formatting is not supported by IRC
                     GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent,
                     RestClientProvider = DefaultRestClientProvider.Create(useProxy: discordProxy != null),
                     WebSocketProvider = DefaultWebSocketProvider.Create(discordProxy != null ? HttpClient.DefaultProxy : null)


### PR DESCRIPTION
This is not generally supported by IRC clients. We also don't generally have much of a use case for this.